### PR TITLE
feat: add repeated test in http ping agent plugin

### DIFF
--- a/agent/plugins/syntests/httpPing/README.md
+++ b/agent/plugins/syntests/httpPing/README.md
@@ -17,8 +17,21 @@ Pings a HTTP endpoint and checks if its the expected response.
     timeoutRetries: 1
 ```
 
+```yaml
+  config : |
+    address: "localhost:9200"
+    expectedCodeRegex : ^(202|472){1}
+    consecutiveTestSuccessCount: 3
+    consecutiveTestInterval: 3s
+```
+
 `retries` is max retry times when http request failed except exceeded timeout
 `timeoutRetries` is optional, default value is 0. Max retry times only when http request exceeded timeout. Recommended value is small number, like 1.
+`retries` and `timeoutRetries` retry the ping test until it http request succeed or reach the max retry times.
+
+`consecutiveTestSuccessCount` is the total http ping test times. If any failure occurs, the final test result will be failed. It conflicts with `retries` and `timeoutRetries`.
+`consecutiveTestInterval` is ping interval in the http ping test. Default value is 5s.
+`retries`/`timeoutRetries` and `consecutiveTestSuccessCount` are mutually exclusive. They can't be larger than 0 at the same time.
 
 For multiple endpoints (performs the tests in parallel):
 

--- a/agent/plugins/syntests/httpPing/README.md
+++ b/agent/plugins/syntests/httpPing/README.md
@@ -7,6 +7,17 @@ Pings a HTTP endpoint and checks if its the expected response.
  1. `key`: `_log`
     - `value`: details of a request
 
+## Configuration Items
+
+| Key                  | Description                                                                                                       | Required | Memo                                                                                                                         |
+|----------------------|-------------------------------------------------------------------------------------------------------------------|----------|------------------------------------------------------------------------------------------------------------------------------|
+| `address`            | The address of the endpoint to ping                                                                               | Yes      |                                                                                                                              |
+| `expectedCodeRegex`  | The expected http response code regex                                                                             | Yes      |                                                                                                                              |
+| `retries`            | The number of max retry times when http request failed                                                            | No       | The final result is successful within the retry attempts.                                                                    |
+| `timeoutRetries`     | The number of max retry times only when http request exceeded timeout. Recommended value is small number, like 1. | No       | The final result is successful within the retry attempts.                                                                    |
+| `repeatsWithoutFail` | The number of total repeated http ping  test times                                                                | No       | The final result is successful only if all repeated tests pass. It’s mutually exclusive with `retries` and `timeoutRetries`. |
+| `waitBetweenRepeats` | The ping interval in the repeated http ping test                                                                  | No       | Default value is 5s.                                                                                                         |
+
 ## Example Configuration
 
 ```yaml
@@ -21,17 +32,9 @@ Pings a HTTP endpoint and checks if its the expected response.
   config : |
     address: "localhost:9200"
     expectedCodeRegex : ^(202|472){1}
-    consecutiveTestSuccessCount: 3
-    consecutiveTestInterval: 3s
+    repeatsWithoutFail: 3
+    waitBetweenRepeats: 3s
 ```
-
-`retries` is max retry times when http request failed except exceeded timeout
-`timeoutRetries` is optional, default value is 0. Max retry times only when http request exceeded timeout. Recommended value is small number, like 1.
-`retries` and `timeoutRetries` retry the ping test until it http request succeed or reach the max retry times.
-
-`consecutiveTestSuccessCount` is the total http ping test times. If any failure occurs, the final test result will be failed. It conflicts with `retries` and `timeoutRetries`.
-`consecutiveTestInterval` is ping interval in the http ping test. Default value is 5s.
-`retries`/`timeoutRetries` and `consecutiveTestSuccessCount` are mutually exclusive. They can't be larger than 0 at the same time.
 
 For multiple endpoints (performs the tests in parallel):
 

--- a/agent/plugins/syntests/httpPing/httpPing.go
+++ b/agent/plugins/syntests/httpPing/httpPing.go
@@ -78,7 +78,8 @@ func (t *HttpPingTest) Initialise(synTestConfig proto.SynTestConfig) error {
 	t.configs = configs
 	for i := range t.configs {
 		if (t.configs[i].MaxRetries > 0 || t.configs[i].MaxTimeoutRetry > 0) && t.configs[i].RepeatWithoutFail > 0 {
-			return errors.New("maxRetries/timeoutRetries and repeatsWithoutFail cannot be larger than 0 at the same time")
+			log.Println("Error: retries/timeoutRetries and repeatsWithoutFail are mutually exclusive and cannot be used together.")
+			return errors.New("retries/timeoutRetries and repeatsWithoutFail cannot be larger than 0 at the same time")
 		}
 		if len(t.configs[i].WaitBetweenRepeat) == 0 {
 			t.configs[i].WaitBetweenRepeat = DefaultWaitBetweenRepeats

--- a/testing/configs/syntest-configs/http-ping-consecutive.yaml
+++ b/testing/configs/syntest-configs/http-ping-consecutive.yaml
@@ -12,4 +12,4 @@ timeouts:
 config: |
   address: https://api64.ipify.org
   expectedCodeRegex: ^(200|302)$
-  consecutiveTestSuccessCount: 2
+  repeatsWithoutFail: 2

--- a/testing/configs/syntest-configs/http-ping-consecutive.yaml
+++ b/testing/configs/syntest-configs/http-ping-consecutive.yaml
@@ -1,0 +1,15 @@
+name: http-ping-consecutive
+labels:
+  foo: bar-1
+pluginName: httpPing
+displayName: HTTP Ping Consecutive Test
+description: HTTP Ping Consecutive Test
+namespace: test-ns-01
+node: "*"
+repeat: 1m
+timeouts:
+  run: 1m
+config: |
+  address: https://api64.ipify.org
+  expectedCodeRegex: ^(200|302)$
+  consecutiveTestSuccessCount: 2


### PR DESCRIPTION
## Description

in agent plugin: `httpPing` add two config params: `repeatsWithoutFail` and `waitBetweenRepeats `

- `repeatsWithoutFail` is the total repeated http ping test times. If any failure occurs, the final test result will be failed. It conflicts with `retries` and `timeoutRetries`.
- no change to current logic of `retries` and `timeoutRetries`.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
