### PR TITLE
Update controller logic to include single node selection with prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ spec:
     retries: 3
 ```
 
+#### Synthetic-test spec functionality
+
+Node selection:
+
+- `node: *`
+  - Run on all nodes
+- `node: worker*`
+  - Run on all nodes with the prefix 'worker'
+- `node: $`
+  - Run on a single (random) node
+- `node: worker$`
+  - Run on a single node with the prefix 'worker'
+
 ### The Agent
 
 ![Synthetic Heart Agent Architecture](./docs/agent_architecture.png)

--- a/chart/synthetic-heart/values.yaml
+++ b/chart/synthetic-heart/values.yaml
@@ -3,9 +3,9 @@
 controller:
   logLevel: INFO
   image:
-    repository: bakshi41c/synheart-controller
-    tag: "v1.2.1"
-    pullPolicy: Always
+    repository: localhost/synheart-controller
+    tag: "dev-latest"
+    pullPolicy: IfNotPresent
   ports:
     - containerPort: 2112 # For prometheus
       protocol: TCP
@@ -28,9 +28,9 @@ agent:
   printPluginLogs: onFail   # Whether to print logs of test runs (always, onFail, never)
   exportRate: 15s           # How often to export health status of plugins/agent
   image:
-    repository: bakshi41c/synheart-agent
-    tag: "v1.2.1-with-py"
-    pullPolicy: Always
+    repository: localhost/synheart-agent
+    tag: "dev-latest"
+    pullPolicy: IfNotPresent
   ports:
     - containerPort: 2112 # For prometheus
       protocol: TCP
@@ -60,9 +60,9 @@ agent:
 restapi:
   logLevel: INFO
   image:
-    repository: bakshi41c/synheart-restapi
-    tag: "v1.2.1"
-    pullPolicy: Always
+    repository: localhost/synheart-restapi
+    tag: "dev-latest"
+    pullPolicy: IfNotPresent
   annotations: {}
   ports:
     - containerPort: 8080


### PR DESCRIPTION
## Description
Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to
related issues, other PRs, or technical references.

Update the controller to be able to schedule a test to a single worker node via a nodename prefix. This functionality is useful for users who wish to schedule a test to a *single* node with a supplied prefix instead of all nodes with a given prefix.

Current `node` selector functionality: 
* `node: *` - Run on all nodes
* `node: worker*` - Run on all nodes with the prefix 'worker'
* `node: $` - Run on a single (random) node
* `node: worker$` - `error: no valid agents found to run the synthetic test on, retry after 1 minute` ! <--- This PR will fix this


## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
