### PR TITLE
Fix golang vulns, bump restapi and controller to 1.23.8

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker.io/library/golang:1.22.5 AS builder
+FROM docker.io/library/golang:1.23.8-alpine3.20 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/restapi/Dockerfile
+++ b/restapi/Dockerfile
@@ -1,7 +1,7 @@
 ############################
 # STEP 1 build the image for creating the executable
 ############################
-FROM docker.io/library/golang:1.23.1-alpine3.20 as builder
+FROM docker.io/library/golang:1.23.8-alpine3.20 as builder
 
 # Install git + SSL ca certificates + make
 # Git is required for fetching the dependencies.


### PR DESCRIPTION
## Description

Bump the golang version for the restapi and controller images to fix vulnerabilities. 

Notable vulnerabilities being fixed are the following: 
- https://nvd.nist.gov/vuln/detail/CVE-2025-22871 <-- critical
- https://nvd.nist.gov/vuln/detail/CVE-2024-34158 <-- high
- https://nvd.nist.gov/vuln/detail/CVE-2024-34156 <-- high

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other Vulnerability Fix

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
