### PR TITLE
fix(curl): kill timed-out curl process group to prevent leaks (#29)

### DIFF
--- a/agent/plugins/syntests/curl/curl.go
+++ b/agent/plugins/syntests/curl/curl.go
@@ -17,20 +17,25 @@
 package main
 
 import (
-	"github.com/cisco-open/synthetic-heart/common"
-	"github.com/cisco-open/synthetic-heart/common/proto"
-	"github.com/hashicorp/go-plugin"
-	"github.com/pkg/errors"
+	"context"
 	"log"
 	"os/exec"
 	"strconv"
 	"strings"
+	"time"
+
+	"github.com/cisco-open/synthetic-heart/agent/utils"
+	"github.com/cisco-open/synthetic-heart/common"
+	"github.com/cisco-open/synthetic-heart/common/proto"
+	"github.com/hashicorp/go-plugin"
+	"github.com/pkg/errors"
 )
 
 const PluginName = "curl"
 
 type CurlTest struct {
-	config CurlTestConfig
+	config      CurlTestConfig
+	curlTimeout time.Duration
 }
 
 type CurlTestConfig struct {
@@ -47,8 +52,19 @@ type OutputOption struct {
 func (t *CurlTest) Initialise(synTestConfig proto.SynTestConfig) error {
 	t.config = CurlTestConfig{}
 	log.Println("parsing config")
-	err := common.ParseYMLConfig(synTestConfig.Config, &t.config)
-	return err
+	if err := common.ParseYMLConfig(synTestConfig.Config, &t.config); err != nil {
+		return err
+	}
+
+	t.curlTimeout = common.DefaultRunTimeout
+	testTimeout, parseErr := time.ParseDuration(synTestConfig.Timeouts.Run)
+	if parseErr != nil {
+		log.Println("warning: run timeout duration could not be parsed, using default", common.DefaultRunTimeout.String())
+		return nil
+	}
+
+	t.curlTimeout = testTimeout
+	return nil
 }
 
 func (t *CurlTest) PerformTest(_ proto.Trigger) (proto.TestResult, error) {
@@ -60,10 +76,12 @@ func (t *CurlTest) PerformTest(_ proto.Trigger) (proto.TestResult, error) {
 	}
 	outputOptionsStr += "'"
 
-	cmd := exec.Command("curl", "-v", "--output", "/dev/null", "--silent", "--write-out", outputOptionsStr, t.config.Url)
+	curlCmd := exec.Command("curl", "-v", "--output", "/dev/null", "--silent", "--write-out", outputOptionsStr, t.config.Url)
 
-	log.Println(cmd.Args)
-	out, err := cmd.CombinedOutput()
+	log.Println(curlCmd.Args)
+	ctx, cancel := context.WithTimeout(context.Background(), t.curlTimeout)
+	defer cancel()
+	out, err := utils.RunWithContext(curlCmd, ctx)
 	if err != nil {
 		log.Println("error executing curl")
 		log.Println(string(out))

--- a/agent/utils/run.go
+++ b/agent/utils/run.go
@@ -1,0 +1,80 @@
+// Copyright 2024 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package utils
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// RunWithContext runs a command with a context and makes sure to kill
+// the subprocess and child processes when the command finishes
+func RunWithContext(c *exec.Cmd, ctx context.Context) ([]byte, error) {
+	c.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	c.Stdout = &stdout
+	c.Stderr = &stderr
+
+	err := c.Start()
+	if err != nil {
+		return nil, err
+	}
+
+	waitErrCh := make(chan error, 1)
+	go func() {
+		waitErrCh <- c.Wait()
+	}()
+
+	select {
+	case waitErr := <-waitErrCh:
+		if ee, ok := waitErr.(*exec.ExitError); ok {
+			combinedError := fmt.Errorf("%w: %s", ee, stderr.String())
+			return stdout.Bytes(), combinedError
+		}
+		return stdout.Bytes(), waitErr
+
+	case <-ctx.Done():
+		cancelErr := ctx.Err()
+		pid := c.Process.Pid
+
+		if killErr := syscall.Kill(-pid, syscall.SIGTERM); killErr != nil && !errors.Is(killErr, syscall.ESRCH) {
+			return stdout.Bytes(), fmt.Errorf("%w: sending SIGTERM to process group: %v", cancelErr, killErr)
+		}
+
+		select {
+		case <-waitErrCh:
+			return stdout.Bytes(), cancelErr
+		case <-time.After(3 * time.Second):
+		}
+
+		if killErr := syscall.Kill(-pid, syscall.SIGKILL); killErr != nil && !errors.Is(killErr, syscall.ESRCH) {
+			return stdout.Bytes(), fmt.Errorf("%w: sending SIGKILL to process group: %v", cancelErr, killErr)
+		}
+
+		<-waitErrCh
+		return stdout.Bytes(), cancelErr
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes a process leak in the curl synthetic test plugin when a test hits `timeouts.run`.  
Previously, a hanging `curl` subprocess could survive plugin timeout/restart cycles, eventually exhausting process/thread limits on the agent (`failed to create new OS thread`, `newosproc`).

### What changed
- Added process-group-aware command execution in run.go via `RunWithContext`:
  - starts command in its own process group
  - on context timeout/cancel, sends `SIGTERM` to the process group
  - escalates to `SIGKILL` after a short grace period if needed
  - waits for process reap before returning
- Updated curl plugin to use this helper and explicit curl timeout field:
  - curl.go

Fixes #29.

## Reviewer Validation

Use this SyntheticTest to validate the changes:
```
apiVersion: synheart.infra.webex.com/v1
kind: SyntheticTest
metadata:
  name: curl-timeout
  namespace: synthetic-heart
  labels:
    infra: "true"
spec:
  plugin: curl
  node: $
  displayName: Curl Timeout Repro
  description: Repro for curl timeout cleanup
  repeat: 20s
  config: |
    url: https://203.0.113.1
    outputOptions:
      - name: time_total
        metric: true
```

1. Build and deploy updated agent image to local kind cluster.
2. Apply above manifest:
   - `kubectl apply -fcurl-timeout-repro.synthetictest.yaml`
3. Let it run for a few cycles.
4. Confirm timeout behavior is logged (`context deadline exceeded`) and **no curl process accumulation** occurs in agent pods.
  - Shell into a synheart-agent pod and run `pstree` to check no `curl` processes are hanging

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass

