### PR TITLE
ci: add docker build workflow for release-triggered multi-arch image builds

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,140 @@
+name: Docker
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+env:
+  PLATFORMS: linux/amd64,linux/arm64
+  REGISTRY: ghcr.io
+
+jobs:
+  build-controller:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Validate tag
+        if: github.ref_type != 'tag'
+        run: |
+          echo "::error::This workflow must be triggered from a tag, not a branch."
+          exit 1
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: ${{ env.PLATFORMS }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: controller/Dockerfile
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}/controller:${{ github.ref_name }}
+          cache-from: type=gha,scope=controller
+          cache-to: type=gha,mode=max,scope=controller
+
+  build-restapi:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Validate tag
+        if: github.ref_type != 'tag'
+        run: |
+          echo "::error::This workflow must be triggered from a tag, not a branch."
+          exit 1
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: ${{ env.PLATFORMS }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: restapi/Dockerfile
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}/restapi:${{ github.ref_name }}
+          cache-from: type=gha,scope=restapi
+          cache-to: type=gha,mode=max,scope=restapi
+
+  build-agent:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - variant: default
+            target: base-with-go-plugins
+            suffix: ""
+          - variant: no-plugins
+            target: base
+            suffix: "-no-plugins"
+          - variant: with-py
+            target: base-with-python-plugins
+            suffix: "-with-py"
+    steps:
+      - name: Validate tag
+        if: github.ref_type != 'tag'
+        run: |
+          echo "::error::This workflow must be triggered from a tag, not a branch."
+          exit 1
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: ${{ env.PLATFORMS }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: agent/Dockerfile
+          target: ${{ matrix.target }}
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}/agent:${{ github.ref_name }}${{ matrix.suffix }}
+          build-args: |
+            SYNHEART_VERSION=${{ github.ref_name }}
+          cache-from: type=gha,scope=agent-${{ matrix.variant }}
+          cache-to: type=gha,mode=max,scope=agent-${{ matrix.variant }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -23,22 +23,22 @@ jobs:
           exit 1
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
         with:
           platforms: ${{ env.PLATFORMS }}
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: controller/Dockerfile
@@ -61,22 +61,22 @@ jobs:
           exit 1
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
         with:
           platforms: ${{ env.PLATFORMS }}
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: restapi/Dockerfile
@@ -111,22 +111,22 @@ jobs:
           exit 1
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
         with:
           platforms: ${{ env.PLATFORMS }}
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: agent/Dockerfile

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -30,13 +30,13 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: 🔍 Detect changes in chart directories
         if: github.event_name != 'workflow_dispatch' && github.ref_type != 'tag'
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         id: filter
         with:
           filters: |
@@ -87,12 +87,12 @@ jobs:
       matrix: ${{ fromJson(needs.detect-changes.outputs.matrix) }}
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: ⚙️ Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: v3.14.0
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,39 @@ A few Kubernetes resources need to be installed:
   - A `Service` for the Restapi is needed.
   - Optionally an `Ingress` can be added to the Restapi to make the API accessible from outside the cluster.
 
+## Releasing
+
+Releasing a new version of Synthetic Heart involves creating a git tag and a GitHub release. This triggers a CI workflow that builds and pushes Docker images to GHCR.
+
+### Docker Images
+
+The following images are built and pushed to `ghcr.io/cisco-open/synthetic-heart/`:
+
+| Image | Description |
+|-------|-------------|
+| `agent:v<version>` | Agent with Go plugins |
+| `agent:v<version>-no-plugins` | Agent without any plugins |
+| `agent:v<version>-with-py` | Agent with Go and Python plugins |
+| `restapi:v<version>` | REST API |
+| `controller:v<version>` | Kubernetes controller |
+
+### Creating a Release
+
+1. Create and push a tag:
+   ```bash
+   git tag v1.2.7
+   git push origin v1.2.7
+   ```
+
+2. Create a GitHub release from the tag:
+   - Go to **Releases** > **Draft a new release**
+   - Select the tag you just pushed
+   - Add release notes and publish
+
+3. The [Docker workflow](./.github/workflows/docker.yaml) triggers automatically and builds all images for `linux/amd64` and `linux/arm64`.
+
+4. If a build fails, you can manually re-trigger the workflow from the **Actions** tab (select the tag, not a branch).
+
 ## Deployment strategies
 
 Please check the [Deployment](./docs/Deployment.md) document for different deployment strategies.

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ The following images are built and pushed to `ghcr.io/cisco-open/synthetic-heart
 ### Creating a Release
 
 1. Create and push a tag:
+
    ```bash
    git tag v1.2.7
    git push origin v1.2.7

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -2,6 +2,8 @@
 # STEP 1 build the image for creating the executable
 ############################
 FROM docker.io/library/golang:1.24.6-alpine3.22 as builder
+ARG TARGETARCH
+ARG SYNHEART_VERSION=v0.0.0
 
 # Install git + SSL ca certificates + make
 RUN apk update && apk upgrade && apk add --no-cache git ca-certificates make unzip g++ && update-ca-certificates && apk --no-cache add openssl wget && rm -rf /var/cache/apk/*
@@ -9,11 +11,12 @@ RUN apk update && apk upgrade && apk add --no-cache git ca-certificates make unz
 # Create appuser
 RUN adduser -D -g '' appuser
 
-# Install protoc
-RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.20.1/protoc-3.20.1-linux-x86_64.zip
-RUN unzip protoc-3.20.1-linux-x86_64.zip
-RUN cp ./bin/protoc /usr/local/bin/protoc
-RUN cp -a ./include/. /usr/local/include/
+# Install protoc (select correct binary for target architecture)
+RUN if [ "$TARGETARCH" = "arm64" ]; then PROTOC_ARCH="aarch_64"; else PROTOC_ARCH="x86_64"; fi && \
+    wget https://github.com/protocolbuffers/protobuf/releases/download/v3.20.1/protoc-3.20.1-linux-${PROTOC_ARCH}.zip && \
+    unzip protoc-3.20.1-linux-${PROTOC_ARCH}.zip && \
+    cp ./bin/protoc /usr/local/bin/protoc && \
+    cp -a ./include/. /usr/local/include/
 
 # Install GRPC golang-plugin for protoc
 RUN go install github.com/golang/protobuf/protoc-gen-go@v1.5.2
@@ -35,7 +38,7 @@ RUN mkdir -p /app/synthetic-heart/
 RUN touch /app/synthetic-heart/.emptyfile
 
 # Compile the binary
-RUN cd agent/ && make build-agent
+RUN cd agent/ && SYNHEART_VERSION=$SYNHEART_VERSION make build-agent
 
 # Move everything to the final location
 RUN mv agent/bin/* /app/synthetic-heart


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow (`.github/workflows/docker.yaml`) to build and push Docker images to GHCR on release publish, with `workflow_dispatch` for manual re-triggers
- Build three images: `agent`, `restapi`, `controller` for `linux/amd64` and `linux/arm64`
- Agent image produces three tag variants per release (e.g. for `v1.2.7`):
  - `v1.2.7` — default with Go plugins
  - `v1.2.7-no-plugins` — base agent only
  - `v1.2.7-with-py` — with Python plugins
- Fix agent Dockerfile to select correct protoc binary based on `TARGETARCH` for multi-arch support
- Pass release version into agent build via `SYNHEART_VERSION` build arg

## Workflow

```
git tag v1.2.7 && git push --tags
→ Create GitHub release from tag
→ Workflow triggers automatically, builds & pushes all images
```

Manual re-trigger is available via `workflow_dispatch` (must select a tag, not a branch).

## Changes

| File | Change |
|------|--------|
| `.github/workflows/docker.yaml` | New workflow with 3 parallel jobs (controller, restapi, agent matrix) |
| `agent/Dockerfile` | Multi-arch protoc download + `SYNHEART_VERSION` build arg |