### PR TITLE
Add IPv6 support to httpPing plugin

### DIFF
--- a/agent/plugins/syntests/httpPing/README.md
+++ b/agent/plugins/syntests/httpPing/README.md
@@ -17,6 +17,7 @@ Pings a HTTP endpoint and checks if its the expected response.
 | `timeoutRetries`     | The number of max retry times only when http request exceeded timeout. Recommended value is small number, like 1. | No       | The final result is successful within the retry attempts.                                                                    |
 | `repeatsWithoutFail` | The number of total repeated http ping  test times                                                                | No       | The final result is successful only if all repeated tests pass. It’s mutually exclusive with `retries` and `timeoutRetries`. |
 | `waitBetweenRepeats` | The ping interval in the repeated http ping test                                                                  | No       | Default value is 5s.                                                                                                         |
+| `ipVersion`          | Force the IP version used by the HTTP connection                                                                  | No       | Supported values are `4` and `6`. When omitted, the Go HTTP client chooses the address family normally.                      |
 
 ## Example Configuration
 
@@ -47,4 +48,21 @@ For multiple endpoints (performs the tests in parallel):
     - address: "localhost:6400"
       expectedCodeRegex : ^(202|472){1}
       retries: 3
+```
+
+To force IPv6 for a dual-stack hostname or IPv6 literal:
+
+```yaml
+  config : |
+    address: "https://example.com"
+    expectedCodeRegex : ^(200|302)$
+    retries: 3
+    ipVersion: 6
+```
+
+```yaml
+  config : |
+    address: "http://[2001:db8::10]:8080/health"
+    expectedCodeRegex : ^200$
+    ipVersion: 6
 ```

--- a/agent/plugins/syntests/httpPing/httpPing.go
+++ b/agent/plugins/syntests/httpPing/httpPing.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"log"
 	"math"
+	"net"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -53,6 +54,7 @@ type HttpPingTestConfig struct {
 	MaxTimeoutRetry   int    `yaml:"timeoutRetries"`
 	RepeatWithoutFail int    `yaml:"repeatsWithoutFail"`
 	WaitBetweenRepeat string `yaml:"waitBetweenRepeats"`
+	IPVersion         int    `yaml:"ipVersion"`
 	timeout           time.Duration
 }
 
@@ -80,6 +82,9 @@ func (t *HttpPingTest) Initialise(synTestConfig proto.SynTestConfig) error {
 		if (t.configs[i].MaxRetries > 0 || t.configs[i].MaxTimeoutRetry > 0) && t.configs[i].RepeatWithoutFail > 0 {
 			log.Println("Error: retries/timeoutRetries and repeatsWithoutFail are mutually exclusive and cannot be used together.")
 			return errors.New("retries/timeoutRetries and repeatsWithoutFail cannot be larger than 0 at the same time")
+		}
+		if err := validateIPVersion(t.configs[i].IPVersion); err != nil {
+			return err
 		}
 		if len(t.configs[i].WaitBetweenRepeat) == 0 {
 			t.configs[i].WaitBetweenRepeat = DefaultWaitBetweenRepeats
@@ -149,6 +154,7 @@ func httpPingTest(_ context.Context, log *log.Logger, d interface{}) (interface{
 	maxTimeoutRetries := d.(HttpPingTestConfig).MaxTimeoutRetry
 	repeatsWithoutFail := d.(HttpPingTestConfig).RepeatWithoutFail
 	waitBetweenRepeats := d.(HttpPingTestConfig).WaitBetweenRepeat
+	ipVersion := d.(HttpPingTestConfig).IPVersion
 	repeatWaitTime, parseErr := time.ParseDuration(waitBetweenRepeats)
 	if parseErr != nil {
 		return result, errors.Wrap(parseErr, "error parsing repeated success test interval")
@@ -159,12 +165,7 @@ func httpPingTest(_ context.Context, log *log.Logger, d interface{}) (interface{
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
-
-	c := http.DefaultClient
-	c.Transport = tr
+	c := newHTTPClient(ipVersion)
 
 	req, err := http.NewRequest("GET", address, nil)
 	if err != nil {
@@ -227,6 +228,29 @@ func httpPingTest(_ context.Context, log *log.Logger, d interface{}) (interface{
 		}
 	}
 	return result, nil
+}
+
+func validateIPVersion(ipVersion int) error {
+	if ipVersion == 0 || ipVersion == 4 || ipVersion == 6 {
+		return nil
+	}
+	return errors.Errorf("invalid ipVersion %d: supported values are 4 or 6", ipVersion)
+}
+
+func newHTTPClient(ipVersion int) *http.Client {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+
+	if ipVersion == 4 || ipVersion == 6 {
+		network := fmt.Sprintf("tcp%d", ipVersion)
+		dialer := &net.Dialer{}
+		tr.DialContext = func(ctx context.Context, _ string, address string) (net.Conn, error) {
+			return dialer.DialContext(ctx, network, address)
+		}
+	}
+
+	return &http.Client{Transport: tr}
 }
 
 func runHttpPing(c *http.Client, req *http.Request, log *log.Logger, expectedCodeRegex string) (bool, time.Duration, error) {

--- a/agent/plugins/syntests/httpPing/httpPing_test.go
+++ b/agent/plugins/syntests/httpPing/httpPing_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cisco-open/synthetic-heart/common/proto"
+)
+
+func TestInitialiseAcceptsSupportedIPVersions(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   string
+		expected int
+	}{
+		{
+			name: "default",
+			config: `
+address: http://example.com
+expectedCodeRegex: ^200$
+`,
+			expected: 0,
+		},
+		{
+			name: "ipv4",
+			config: `
+address: http://example.com
+expectedCodeRegex: ^200$
+ipVersion: 4
+`,
+			expected: 4,
+		},
+		{
+			name: "ipv6",
+			config: `
+address: http://example.com
+expectedCodeRegex: ^200$
+ipVersion: 6
+`,
+			expected: 6,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			test := &HttpPingTest{}
+			if err := test.Initialise(synTestConfig(tt.config)); err != nil {
+				t.Fatalf("Initialise returned error: %v", err)
+			}
+			if got := test.configs[0].IPVersion; got != tt.expected {
+				t.Fatalf("expected ipVersion %d, got %d", tt.expected, got)
+			}
+			if got := test.configs[0].WaitBetweenRepeat; got != DefaultWaitBetweenRepeats {
+				t.Fatalf("expected default waitBetweenRepeats %q, got %q", DefaultWaitBetweenRepeats, got)
+			}
+		})
+	}
+}
+
+func TestInitialiseRejectsUnsupportedIPVersion(t *testing.T) {
+	test := &HttpPingTest{}
+	err := test.Initialise(synTestConfig(`
+address: http://example.com
+expectedCodeRegex: ^200$
+ipVersion: 5
+`))
+	if err == nil {
+		t.Fatal("expected unsupported ipVersion to fail")
+	}
+	if !strings.Contains(err.Error(), "invalid ipVersion 5") {
+		t.Fatalf("expected invalid ipVersion error, got %v", err)
+	}
+}
+
+func TestHTTPPingDefaultAddressSelection(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	config := HttpPingTestConfig{
+		Address:           server.URL,
+		ExpectedCodeRegex: "^200$",
+		WaitBetweenRepeat: DefaultWaitBetweenRepeats,
+		timeout:           5 * time.Second,
+	}
+
+	result, err := httpPingTest(context.Background(), log.New(io.Discard, "", 0), config)
+	if err != nil {
+		t.Fatalf("httpPingTest returned error: %v", err)
+	}
+	values := result.(map[string]int)
+	if values["marks"] != 1 {
+		t.Fatalf("expected one mark for successful default HTTP ping, got %d", values["marks"])
+	}
+}
+
+func TestHTTPPingForcedIPv6(t *testing.T) {
+	listener, err := net.Listen("tcp6", "[::1]:0")
+	if err != nil {
+		t.Skipf("IPv6 loopback is not available: %v", err)
+	}
+
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		}),
+	}
+	go func() {
+		if serveErr := server.Serve(listener); serveErr != nil && serveErr != http.ErrServerClosed {
+			t.Errorf("IPv6 test server failed: %v", serveErr)
+		}
+	}()
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = server.Shutdown(ctx)
+	}()
+
+	addr := listener.Addr().(*net.TCPAddr)
+	config := HttpPingTestConfig{
+		Address:           fmt.Sprintf("http://[%s]:%d", addr.IP.String(), addr.Port),
+		ExpectedCodeRegex: "^200$",
+		WaitBetweenRepeat: DefaultWaitBetweenRepeats,
+		IPVersion:         6,
+		timeout:           5 * time.Second,
+	}
+
+	result, err := httpPingTest(context.Background(), log.New(io.Discard, "", 0), config)
+	if err != nil {
+		t.Fatalf("httpPingTest returned error: %v", err)
+	}
+	values := result.(map[string]int)
+	if values["marks"] != 1 {
+		t.Fatalf("expected one mark for successful IPv6 HTTP ping, got %d", values["marks"])
+	}
+}
+
+func synTestConfig(config string) proto.SynTestConfig {
+	return proto.SynTestConfig{
+		Timeouts: &proto.Timeouts{Run: "1m"},
+		Config:   config,
+	}
+}


### PR DESCRIPTION
## Description

  Adds optional IPv6 support to the existing `httpPing` plugin without introducing a separate `httpPing6`
  plugin.

  This change adds an `ipVersion` config field for each HTTP ping target:

  - omitted or `0`: preserve existing Go HTTP client address-family behavior
  - `4`: force TCP over IPv4 (`tcp4`)
  - `6`: force TCP over IPv6 (`tcp6`)

  The implementation also avoids mutating `http.DefaultClient` by constructing a dedicated HTTP client per
  ping job. The plugin README documents `ipVersion` and includes IPv6 examples.

  ## Type of Change

  - [ ] Bug Fix
  - [x] New Feature
  - [ ] Breaking Change
  - [ ] Refactor
  - [x] Documentation
  - [ ] Other (please describe)

  ## Checklist

  - [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
  - [x] Existing issues have been referenced (where applicable)
  - [x] I have verified this change is not present in other open pull requests
  - [x] Functionality is documented
  - [x] All code style checks pass
  - [x] New code contribution is covered by automated tests
  - [ ] All new and existing tests pass

  Testing performed:

  - Ran `gofmt` on the changed `httpPing` Go files.
  - Ran `go test ./plugins/syntests/httpPing` from `agent`.
  - Ran `make build-agent` from `agent` to verify the agent and bundled Go plugins compile.
  - Built local Podman images for agent, controller, and REST API.
  - Loaded the images into a local Kind cluster.
  - Installed the `synthetic-heart` Helm chart in a local Kind cluster.
  - Created a dual-stack Kind test setup with an IPv6-only `ipv6-http-echo` Kubernetes Service.
  - Created a `SyntheticTest` using `plugin: httpPing` and `ipVersion: 6` targeting `http://ipv6-http-
  echo.synthetic-heart-tests.svc.cluster.local:8080/echo?msg=ok`.
  - Verified through the REST API that both agents reported `1.00000` for `http-ping-ipv6-echo` and `/api/
  v1/ping` returned `Healthy` with `No failed tests`.