### PR TITLE
fix(restapi): allow dots in synthetic test IDs

### DIFF
--- a/restapi/main.go
+++ b/restapi/main.go
@@ -39,7 +39,12 @@ import (
 	"time"
 )
 
-const PingRefreshFrequency = 15 * time.Second
+const (
+	PingRefreshFrequency = 15 * time.Second
+	pathSegmentPattern   = `[A-Za-z0-9.-]+`
+	configIDPattern      = pathSegmentPattern + `\/` + pathSegmentPattern
+	pluginIDPattern      = configIDPattern + `\/` + pathSegmentPattern + `\/` + pathSegmentPattern
+)
 
 type RestApi struct {
 	config        RestApiConfig
@@ -96,22 +101,7 @@ func NewRestApi(configPath string) (*RestApi, error) {
 	r.config = pluginConfig
 
 	router := gmux.NewRouter()
-
-	// Setup HTTP response
-	router.HandleFunc("/ui", r.RedirectToUi)
-
-	router.HandleFunc("/api/v1/ping", r.GetPing)
-	router.HandleFunc("/api/v1/agents", r.GetAllAgents)
-	router.HandleFunc("/api/v1/testconfigs/summary", r.GetAllTests)
-	router.HandleFunc("/api/v1/testconfig/{id:[a-zA-z0-9-]+\\/[a-zA-z0-9-]+}", r.GetTestConfig)
-	router.HandleFunc("/api/v1/plugins/status", r.GetAllPluginStatus)
-	router.HandleFunc("/api/v1/plugin/{id:[a-zA-z0-9-]+\\/[a-zA-z0-9-]+\\/[a-zA-z0-9-]+\\/[a-zA-z0-9-]+}/health", r.GetPluginHealth)
-	router.HandleFunc("/api/v1/plugin/{id:[a-zA-z0-9-]+\\/[a-zA-z0-9-]+\\/[a-zA-z0-9-]+\\/[a-zA-z0-9-]+}/lastUnhealthy", r.GetPluginHealth)
-	router.HandleFunc("/api/v1/testruns/status", r.GetAllTestStatus)
-	router.HandleFunc("/api/v1/testrun/{id:[a-zA-z0-9-]+\\/[a-zA-z0-9-]+\\/[a-zA-z0-9-]+\\/[a-zA-z0-9-]+}/latest", r.GetTestRun)
-	router.HandleFunc("/api/v1/testrun/{id:[a-zA-z0-9-]+\\/[a-zA-z0-9-]+\\/[a-zA-z0-9-]+\\/[a-zA-z0-9-]+}/lastFailed", r.GetTestRun)
-	router.HandleFunc("/api/v1/testrun/{id:[a-zA-z0-9-]+\\/[a-zA-z0-9-]+\\/[a-zA-z0-9-]+\\/[a-zA-z0-9-]+}/latest/logs", r.GetTestLogs)
-	router.HandleFunc("/api/v1/testrun/{id:[a-zA-z0-9-]+\\/[a-zA-z0-9-]+\\/[a-zA-z0-9-]+\\/[a-zA-z0-9-]+}/lastFailed/logs", r.GetTestLogs)
+	r.registerRoutes(router)
 
 	if pluginConfig.DebugMode {
 		router.PathPrefix("/debug/").Handler(http.DefaultServeMux)
@@ -128,6 +118,24 @@ func NewRestApi(configPath string) (*RestApi, error) {
 	r.store = extStore
 
 	return &r, nil
+}
+
+func (r *RestApi) registerRoutes(router *gmux.Router) {
+	// Setup HTTP response
+	router.HandleFunc("/ui", r.RedirectToUi)
+
+	router.HandleFunc("/api/v1/ping", r.GetPing)
+	router.HandleFunc("/api/v1/agents", r.GetAllAgents)
+	router.HandleFunc("/api/v1/testconfigs/summary", r.GetAllTests)
+	router.HandleFunc("/api/v1/testconfig/{id:"+configIDPattern+"}", r.GetTestConfig)
+	router.HandleFunc("/api/v1/plugins/status", r.GetAllPluginStatus)
+	router.HandleFunc("/api/v1/plugin/{id:"+pluginIDPattern+"}/health", r.GetPluginHealth)
+	router.HandleFunc("/api/v1/plugin/{id:"+pluginIDPattern+"}/lastUnhealthy", r.GetPluginHealth)
+	router.HandleFunc("/api/v1/testruns/status", r.GetAllTestStatus)
+	router.HandleFunc("/api/v1/testrun/{id:"+pluginIDPattern+"}/latest", r.GetTestRun)
+	router.HandleFunc("/api/v1/testrun/{id:"+pluginIDPattern+"}/lastFailed", r.GetTestRun)
+	router.HandleFunc("/api/v1/testrun/{id:"+pluginIDPattern+"}/latest/logs", r.GetTestLogs)
+	router.HandleFunc("/api/v1/testrun/{id:"+pluginIDPattern+"}/lastFailed/logs", r.GetTestLogs)
 }
 
 func (r *RestApi) Finish() error {

--- a/restapi/main_test.go
+++ b/restapi/main_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	gmux "github.com/gorilla/mux"
+)
+
+func TestRoutesAcceptDottedIDs(t *testing.T) {
+	const (
+		configID = "sip-ping-test-sip.wxsel-access1-mccdev-ocp.us-txwrtm1.dev.infra.webex.com-8934/wxc-edge"
+		pluginID = configID + "/synheart-agent-xtww8/synthetic-heart"
+	)
+
+	tests := []struct {
+		name   string
+		path   string
+		wantID string
+	}{
+		{name: "test config", path: "/api/v1/testconfig/" + configID, wantID: configID},
+		{name: "plugin health", path: "/api/v1/plugin/" + pluginID + "/health", wantID: pluginID},
+		{name: "plugin last unhealthy", path: "/api/v1/plugin/" + pluginID + "/lastUnhealthy", wantID: pluginID},
+		{name: "latest test run", path: "/api/v1/testrun/" + pluginID + "/latest", wantID: pluginID},
+		{name: "last failed test run", path: "/api/v1/testrun/" + pluginID + "/lastFailed", wantID: pluginID},
+		{name: "latest logs", path: "/api/v1/testrun/" + pluginID + "/latest/logs", wantID: pluginID},
+		{name: "last failed logs", path: "/api/v1/testrun/" + pluginID + "/lastFailed/logs", wantID: pluginID},
+	}
+
+	router := gmux.NewRouter()
+	(&RestApi{}).registerRoutes(router)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			match := &gmux.RouteMatch{}
+			if !router.Match(request, match) {
+				t.Fatalf("route did not match %q", tt.path)
+			}
+			if got := match.Vars["id"]; got != tt.wantID {
+				t.Fatalf("route id = %q, want %q", got, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestRoutesRejectExtraIDSegment(t *testing.T) {
+	const pluginID = "test-name/test-namespace/agent-name/plugin-name"
+
+	router := gmux.NewRouter()
+	(&RestApi{}).registerRoutes(router)
+
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/testrun/"+pluginID+"/latest/logs/extra", nil)
+	if router.Match(request, &gmux.RouteMatch{}) {
+		t.Fatal("route matched an extra path segment")
+	}
+}


### PR DESCRIPTION
## Description

Synthetic test names can contain fully qualified domain names. The REST API's Gorilla mux route patterns only accepted letters, digits, and hyphens, so requests for dotted test IDs returned a router-level 404 before reaching their handlers.

This change:

- allows dots in test-config, plugin, and test-run ID path segments;
- reuses the same ID patterns across the affected routes; and
- adds regression coverage for all seven affected endpoints using a representative SipPing FQDN identifier.

Related internal issue: WXCNP-91678

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Validation

- `cd restapi && go test ./...`
- `cd restapi && go build ./...`
- `cd restapi && go vet ./...`
- `gofmt` and `git diff --check`
- Built and security-scanned a production-equivalent FIPS image from commit `1e2f9b5`, then ran it as an isolated dev-cluster canary against live Redis data:
  - the deployed release returned a router-level 404 for the affected dotted config and plugin IDs;
  - the patched image returned the existing test config, plugin health, and latest test run;
  - an existing non-dotted ID continued to resolve; and
  - an extra path segment remained rejected with 404.
- The canary was never selected by the live Service and was removed after validation.

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
